### PR TITLE
Issue #37. Support for npm - added package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "ckeditor",
+    "version": "4.5.6",
+    "description": "JavaScript WYSIWYG web text editor.",
+    "main": "ckeditor.js",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/ckeditor/ckeditor-releases.git"
+    },
+    "keywords": [
+        "ckeditor",
+        "fckeditor",
+        "editor",
+        "wysiwyg",
+        "html",
+        "richtext",
+        "text",
+        "javascript"
+    ],
+    "author": "CKSource (http://cksource.com/)",
+    "license": "SEE LICENSE IN LICENSE.md",
+    "bugs": {
+        "url": "http://dev.ckeditor.com"
+    },
+    "homepage": "http://ckeditor.com"
+}


### PR DESCRIPTION
I added package.json file which will make it possible to use (and publish) ckeditor release with npm. Not sure when it should be merged but probably during next release, because the next thing which should be done and I am currently working on is to adjust ck-release script/tool to automatically publish new releases into npm.